### PR TITLE
Document pre-requisite initialization of coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ npm install graphology-layout-forceatlas2
 
 ## Usage
 
+* [Pre-requisite](#pre-requisite)
 * [Settings](#settings)
 * [Synchronous layout](#synchronous-layout)
 * [Webworker](#webworker)
 * [#.inferSettings](#infersettings)
+
+### Pre-requisite
+
+Two attributes called `x` and `y` must be defined for all the graph nodes beforehand. [Graphology-layout](https://github.com/graphology/graphology-layout) can be used to initialize these attributes.
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install graphology-layout-forceatlas2
 
 ### Pre-requisite
 
-Two attributes called `x` and `y` must be defined for all the graph nodes beforehand. [Graphology-layout](https://github.com/graphology/graphology-layout) can be used to initialize these attributes.
+Each node's starting position must be set before running ForceAtlas 2 layout. Two attributes called `x` and `y` must therefore be defined for all the graph nodes. [Graphology-layout](https://github.com/graphology/graphology-layout) can be used to initialize these attributes to a random or circular layout, if needed.
 
 ### Settings
 

--- a/helpers.js
+++ b/helpers.js
@@ -118,8 +118,8 @@ exports.graphToByteArrays = function(graph) {
     index[nodes[i]] = j;
 
     // Populating byte array
-    NodeMatrix[j] = graph.getNodeAttribute(nodes[i], 'x') || 0;
-    NodeMatrix[j + 1] = graph.getNodeAttribute(nodes[i], 'y') || 0;
+    NodeMatrix[j] = graph.getNodeAttribute(nodes[i], 'x');
+    NodeMatrix[j + 1] = graph.getNodeAttribute(nodes[i], 'y');
     NodeMatrix[j + 2] = 0;
     NodeMatrix[j + 3] = 0;
     NodeMatrix[j + 4] = 0;

--- a/helpers.js
+++ b/helpers.js
@@ -118,8 +118,8 @@ exports.graphToByteArrays = function(graph) {
     index[nodes[i]] = j;
 
     // Populating byte array
-    NodeMatrix[j] = graph.getNodeAttribute(nodes[i], 'x');
-    NodeMatrix[j + 1] = graph.getNodeAttribute(nodes[i], 'y');
+    NodeMatrix[j] = graph.getNodeAttribute(nodes[i], 'x') || 0;
+    NodeMatrix[j + 1] = graph.getNodeAttribute(nodes[i], 'y') || 0;
     NodeMatrix[j + 2] = 0;
     NodeMatrix[j + 3] = 0;
     NodeMatrix[j + 4] = 0;


### PR DESCRIPTION
The layout fails whenever `x` and `y` attributes are not set in the input graph.

As a result, `layout` returns `x:NaN, y: NaN` for all the nodes.

This change initializes coordinates to 0 whenever they are not already defined in the graph.